### PR TITLE
Payment specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,13 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new("spec")
+
+task :default => :spec
+
+task :console do
+  require 'pry'
+  require 'conekticut'
+  ARGV.clear
+  Pry.start
+end

--- a/conekticut.gemspec
+++ b/conekticut.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency("rspec", "~> 2.14.1")
   spec.add_development_dependency('shoulda', '~> 3.5.0')
+  spec.add_development_dependency('pry')
 end

--- a/lib/conekticut/client/configuration.rb
+++ b/lib/conekticut/client/configuration.rb
@@ -6,9 +6,9 @@ module Conekticut
       included do
         add_config_option :public_key
         add_config_option :private_key
-        add_config_option :conekta_version, "'0.2.0'"
+        add_config_option :conekta_version, "'0.4.4'"
         add_config_option :api_base_path, "'https://api.conekta.io'"
-        add_config_option :api_version
+        add_config_option :api_version, "'0.3.0'"
         add_config_option :use_ssl
         add_config_option :ssl_cert_path
       end

--- a/lib/conekticut/client/payment.rb
+++ b/lib/conekticut/client/payment.rb
@@ -13,7 +13,7 @@ module Conekticut
 
         request_options = {
           :headers => {
-            :user_agent => "Conekta RubyBindings/#{Base.conekta_version}",
+            :user_agent => "Conekta/v1 RubyBindings/#{Base.conekta_version}",
             :authorization => "Basic #{::Base64.encode64("#{Base.private_key}:")}",
             :accept=>"application/vnd.conekta-v#{ Base.api_version }+json"
           }, :method => :post, :open_timeout => 30,

--- a/spec/client/payment_spec.rb
+++ b/spec/client/payment_spec.rb
@@ -5,6 +5,7 @@ describe Conekticut::Client::Payment do
   before :each do
     Conekticut.configure do |c|
       c.public_key = "1tv5yJp3xnVZ7eK67m4h"
+      c.private_key = "1tv5yJp3xnVZ7eK67m4h"
       c.ssl_cert_path = "spec/factories/ssl_cert.crt"
       @payments_status_list = ["paid", "pending_payment"]
     end
@@ -14,7 +15,7 @@ describe Conekticut::Client::Payment do
     context "when incorrect data was submited" do
       it "send request to conekta servers" do
         payment_info = { "card"=> {} }
-        response = Conekticut::Client::Payment.create("/charges", payment_info)
+        response = Conekticut::Client::Payment.create("charges", payment_info)
         response["status"].should eq 422
       end
     end
@@ -43,7 +44,7 @@ describe Conekticut::Client::Payment do
             }
           }
 
-          response = Conekticut::Client::Payment.create("/charges", payment_info)
+          response = Conekticut::Client::Payment.create("charges", payment_info)
           @payments_status_list.should include(response["status"])
         end
       end
@@ -65,7 +66,7 @@ describe Conekticut::Client::Payment do
             }
           }
 
-          response = Conekticut::Client::Payment.create("/charges", payment_info)
+          response = Conekticut::Client::Payment.create("charges", payment_info)
           @payments_status_list.should include(response["status"])
         end
       end
@@ -77,7 +78,7 @@ describe Conekticut::Client::Payment do
             "amount"=>20000,
             "description"=>"Stogies",
             "reference_id"=>"9839-wolf_pack",
-            "bank"=> {
+            "cash"=> {
               "type"=>"oxxo"
             },
             "details"=> {
@@ -87,7 +88,7 @@ describe Conekticut::Client::Payment do
             }
           }
 
-          response = Conekticut::Client::Payment.create("/charges", payment_info)
+          response = Conekticut::Client::Payment.create("charges", payment_info)
           @payments_status_list.should include(response["status"])
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 # Require this file using `require "spec_helper"` to ensure that it is only
 # loaded once.
 require "conekticut"
+require 'pry'
 
 # Load files from support directory
 Dir["./spec/support/**/*.rb"].sort.each {|f| require f}


### PR DESCRIPTION
Fixes 3 of 4 specs for `Conekticut::Client::Payment`. Remaining broken spec is due to the card tokenizing requirement on Conekta's API

**pending ideas**
- Add a `Conekticut::Client::Card` class that handles a credit/debit card data and proper validations.
- Add a `Conekticut::Client::Tokenizer` class that handles `tokenizing` a card by implementing `Conekta.js` library functionality, [available here](https://conektaapi.s3.amazonaws.com/v0.3.0/js/conekta.js)
